### PR TITLE
add bmcheck and fix bad reference

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -3,6 +3,25 @@
   "aliases": {
     "byteman": {
       "script-ref": "org.jboss.byteman:byteman:RELEASE"
+    },
+    "bmcheck": {
+      "script-ref": "org.jboss.byteman:byteman:RELEASE",
+      "main": "org.jboss.byteman.check.TestScript"
+    },
+    "bminstall": {
+      "script-ref": "org.jboss.byteman:byteman-install:RELEASE",
+      "dependencies": [
+        "org.jboss.byteman:byteman:RELEASE"
+      ],
+      "main": "org.jboss.byteman.agent.install.Install",
+      "enable-preview": false,
+      "java-agents": []
+    },
+    "bmsubmit": {
+      "script-ref": "org.jboss.byteman:byteman-submit:RELEASE",
+      "main": "org.jboss.byteman.agent.submit.Submit",
+      "enable-preview": false,
+      "java-agents": []
     }
   },
   "templates": {}

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ To install byteman on a remote system you can use the `bminstall` command:
 jbang bminstall@bytemanproject -b <pid>
 ```
 
-## Submit byteman scripts remotely
+## Submit Byteman scripts remotely
 
 To submit byteman scripts to a remote system you can use the `bmsubmit` command:
 

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ All without requiring to install or setup byteman nor java.
 
 ## Install Byteman remotely
 
-To install byteman on a remote system you can use the `bminstall` command:
+To install Byteman on a remote system you can use the `bminstall` command:
 
 ```
 jbang bminstall@bytemanproject -b <pid>

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ To submit Byteman scripts to a remote system you can use the `bmsubmit` command:
 jbang bmsubmit@bytemanproject myfile.btm
 ```
 
-## Check byteman scripts
+## Check Byteman scripts
 
 To check your Byteman scripts you can use the `bmcheck` command:
 

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ jbang bmsubmit@bytemanproject myfile.btm
 
 ## Check byteman scripts
 
-To check your byteman scripts you can use the `bmcheck` command:
+To check your Byteman scripts you can use the `bmcheck` command:
 
 ``` 
 jbang bmcheck@bytemanproject myfile.btm

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ jbang bminstall@bytemanproject -b <pid>
 
 ## Submit Byteman scripts remotely
 
-To submit byteman scripts to a remote system you can use the `bmsubmit` command:
+To submit Byteman scripts to a remote system you can use the `bmsubmit` command:
 
 ```
 jbang bmsubmit@bytemanproject myfile.btm

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ byteman manually. Useful if exploring things on a new/remote system or in a cont
 
 ## Run applications with jbang and byteman 
 
-To run a jar, maven artifact or jbang script with byteman as agent:
+To run a jar, maven artifact or jbang script with Byteman as agent:
 
 ```
 jbang --javaagent byteman@bytemanproject your.jar

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ This catalog enables using byteman via [jbang.dev](https://jbang.dev).
 The usecase for jbang with byteman is that you do not need to download/install
 byteman manually. Useful if exploring things on a new/remote system or in a container.
 
-## Run applications with jbang and byteman 
+## Run applications with Jbang and Byteman 
 
 To run a jar, maven artifact or jbang script with Byteman as agent:
 

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ Combining it all you can do this:
  jbang --javaagent=byteman@bytemanproject=boot:`jbang info classpath byteman@bytemanproject`,script:%{https://github.com/bytemanproject/byteman/raw/main/sample/scripts/FileMonitor.btm} jarviz@kordamp
 ```
 
-This runs `jarviz@kordamp` loads the `byteman@bytemanproject` as a javaagent, adds the necessary classpath to boot path and remotely fetches the FileMonitor.btm available in byteman main repo.
+This runs `jarviz@kordamp` loads the `byteman@bytemanproject` as a javaagent, adds the necessary classpath to boot path and remotely fetches the FileMonitor.btm available in Byteman main repo.
 
 All without requiring to install or setup byteman nor java.
 

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,8 @@ This catalog enables using byteman via [jbang.dev](https://jbang.dev).
 The usecase for jbang with byteman is that you do not need to download/install
 byteman manually. Useful if exploring things on a new/remote system or in a container.
 
+## Run applications with jbang and byteman 
+
 To run a jar, maven artifact or jbang script with byteman as agent:
 
 ```
@@ -28,16 +30,40 @@ jbang --javaagent byteman@bytemanproject:script=%{https://url/to/myfile.btm} you
 If you need to add byteman or other jars to boot classpath you can use this trick:
 
 ```
- jbang --javaagent=byteman@bytemanproject=boot:`jbang info classpath byteman@maxandersen` your.jar
+ jbang --javaagent=byteman@bytemanproject=boot:`jbang info classpath byteman@bytemanproject` your.jar
 ```
 
 Combining it all you can do this:
 
 ```
- jbang --javaagent=byteman@bytemanproject=boot:`jbang info classpath byteman@maxandersen`,script:%{https://github.com/bytemanproject/byteman/raw/main/sample/scripts/FileMonitor.btm} jarviz@kordamp
+ jbang --javaagent=byteman@bytemanproject=boot:`jbang info classpath byteman@bytemanproject`,script:%{https://github.com/bytemanproject/byteman/raw/main/sample/scripts/FileMonitor.btm} jarviz@kordamp
 ```
 
 This runs `jarviz@kordamp` loads the `byteman@bytemanproject` as a javaagent, adds the necessary classpath to boot path and remotely fetches the FileMonitor.btm available in byteman main repo.
 
 All without requiring to install or setup byteman nor java.
+
+## Install Byteman remotely
+
+To install byteman on a remote system you can use the `bminstall` command:
+
+```
+jbang bminstall@bytemanproject -b <pid>
+```
+
+## Submit byteman scripts remotely
+
+To submit byteman scripts to a remote system you can use the `bmsubmit` command:
+
+```
+jbang bmsubmit@bytemanproject myfile.btm
+```
+
+## Check byteman scripts
+
+To check your byteman scripts you can use the `bmcheck` command:
+
+``` 
+jbang bmcheck@bytemanproject myfile.btm
+```
 


### PR DESCRIPTION
realised bmcheck was possible to run directly and saw maxandersen where it should be bytemanproject.

then also realised bmsubmit and bminstall is useful.

With this I can do this to install a remote (or local) script to any java app (my usecase being quarkus dev mode):

```
jbang bminstall@bytemanproject <pid>
jbang bmsubmit@bytemanproject %{https://github.com/bytemanproject/byteman/raw/main/sample/scripts/FileMonitor.btm}
```

